### PR TITLE
Integrate status effects into weapons

### DIFF
--- a/Assets/Scripts/Status/StatusController.cs
+++ b/Assets/Scripts/Status/StatusController.cs
@@ -1,0 +1,155 @@
+using System.Collections.Generic;
+using UnityEngine;
+
+public enum StatusType { Fire, Ice, Lightning }
+public enum DamageTag { Physical, Fire, Ice, Lightning }
+
+public struct StatusEffect
+{
+    public StatusType type;
+    public float magnitude;
+    public float duration;
+    public float tickInterval;
+    public int stacks;
+}
+
+public interface IStatusReceiver
+{
+    void ApplyStatus(StatusEffect e);
+    bool HasStatus(StatusType t);
+    void RemoveStatus(StatusType t);
+}
+
+/// <summary>
+/// Controls application and ticking of status effects.
+/// </summary>
+public class StatusController : MonoBehaviour, IStatusReceiver
+{
+    private class ActiveStatus
+    {
+        public StatusEffect effect;
+        public float timer;
+        public float tickTimer;
+    }
+
+    [SerializeField] private float miniChainRange = 2f;
+    [SerializeField] private float miniChainDamage = 1f;
+    [SerializeField] private int freezeThreshold = 5;
+
+    private readonly Dictionary<StatusType, ActiveStatus> statuses = new();
+
+    public void ApplyStatus(StatusEffect e)
+    {
+        if (statuses.TryGetValue(e.type, out var active))
+        {
+            switch (e.type)
+            {
+                case StatusType.Fire:
+                    active.effect.magnitude += e.magnitude;
+                    active.effect.duration = Mathf.Max(active.effect.duration, e.duration);
+                    active.effect.tickInterval = e.tickInterval;
+                    break;
+                case StatusType.Ice:
+                    if (e.magnitude > active.effect.magnitude)
+                        active.effect.magnitude = e.magnitude;
+                    active.effect.stacks += e.stacks;
+                    active.effect.duration = Mathf.Max(active.effect.duration, e.duration);
+                    break;
+                case StatusType.Lightning:
+                    active.effect.stacks += e.stacks;
+                    active.effect.magnitude = Mathf.Max(active.effect.magnitude, e.magnitude);
+                    active.effect.duration = Mathf.Max(active.effect.duration, e.duration);
+                    active.effect.tickInterval = e.tickInterval;
+                    break;
+            }
+            active.timer = 0f;
+        }
+        else
+        {
+            statuses[e.type] = new ActiveStatus { effect = e, timer = 0f, tickTimer = 0f };
+        }
+    }
+
+    public bool HasStatus(StatusType t) => statuses.ContainsKey(t);
+
+    public void RemoveStatus(StatusType t) => statuses.Remove(t);
+
+    public float GetSpeedMultiplier()
+    {
+        float mult = 1f;
+        if (statuses.TryGetValue(StatusType.Ice, out var ice))
+        {
+            mult *= Mathf.Clamp01(1f - ice.effect.magnitude);
+            if (ice.effect.stacks >= freezeThreshold)
+                mult = 0f;
+        }
+        return mult;
+    }
+
+    public float GetDamageTakenMultiplier(DamageTag tag)
+    {
+        float mult = 1f;
+        if (tag == DamageTag.Lightning && statuses.TryGetValue(StatusType.Lightning, out var l))
+        {
+            mult *= 1f + l.effect.magnitude;
+        }
+        return mult;
+    }
+
+    private void Update()
+    {
+        float dt = Time.deltaTime;
+        var remove = new List<StatusType>();
+        foreach (var kvp in statuses)
+        {
+            var st = kvp.Value;
+            st.timer += dt;
+            if (st.timer >= st.effect.duration)
+            {
+                remove.Add(kvp.Key);
+                continue;
+            }
+            if (st.effect.tickInterval > 0f)
+            {
+                st.tickTimer += dt;
+                if (st.tickTimer >= st.effect.tickInterval)
+                {
+                    st.tickTimer = 0f;
+                    switch (kvp.Key)
+                    {
+                        case StatusType.Fire:
+                            var enemy = GetComponent<EnemyBase>();
+                            if (enemy != null)
+                            {
+                                float dmg = st.effect.magnitude;
+                                enemy.TakeDamage(dmg);
+                            }
+                            break;
+                        case StatusType.Lightning:
+                            ChainLightning(st.effect);
+                            break;
+                    }
+                }
+            }
+            kvp.Value.timer = st.timer;
+            kvp.Value.tickTimer = st.tickTimer;
+        }
+        foreach (var t in remove)
+            statuses.Remove(t);
+    }
+
+    private void ChainLightning(StatusEffect e)
+    {
+        Collider2D[] cols = Physics2D.OverlapCircleAll(transform.position, miniChainRange, LayerMask.GetMask("Enemy"));
+        foreach (var c in cols)
+        {
+            if (c.gameObject == gameObject) continue;
+            var enemy = c.GetComponent<EnemyBase>();
+            if (enemy != null)
+            {
+                enemy.TakeDamage(miniChainDamage);
+                break;
+            }
+        }
+    }
+}

--- a/Assets/Scripts/Utils/SimpleObjectPool.cs
+++ b/Assets/Scripts/Utils/SimpleObjectPool.cs
@@ -1,0 +1,88 @@
+using System.Collections;
+using System.Collections.Generic;
+using UnityEngine;
+
+/// <summary>
+/// 간단한 오브젝트 풀 (싱글톤)
+/// </summary>
+public class SimpleObjectPool : MonoBehaviour
+{
+    public static SimpleObjectPool Instance { get; private set; }
+
+    private class PoolMember : MonoBehaviour
+    {
+        public int key;
+    }
+
+    private readonly Dictionary<int, Stack<GameObject>> pool = new Dictionary<int, Stack<GameObject>>();
+
+    private void Awake()
+    {
+        if (Instance != null && Instance != this)
+        {
+            Destroy(gameObject);
+            return;
+        }
+        Instance = this;
+        DontDestroyOnLoad(gameObject);
+    }
+
+    /// <summary>
+    /// 풀에서 오브젝트 가져오기 (없으면 Instantiate)
+    /// </summary>
+    public GameObject Get(GameObject prefab, Vector3 pos, Quaternion rot)
+    {
+        if (prefab == null) return null;
+
+        int key = prefab.GetInstanceID();
+        if (!pool.TryGetValue(key, out Stack<GameObject> stack))
+        {
+            stack = new Stack<GameObject>();
+            pool[key] = stack;
+        }
+
+        GameObject obj;
+        if (stack.Count > 0)
+        {
+            obj = stack.Pop();
+            obj.transform.SetPositionAndRotation(pos, rot);
+            obj.SetActive(true);
+        }
+        else
+        {
+            obj = Instantiate(prefab, pos, rot);
+            var member = obj.GetComponent<PoolMember>();
+            if (member == null) member = obj.AddComponent<PoolMember>();
+            member.key = key;
+        }
+        return obj;
+    }
+
+    /// <summary>
+    /// 오브젝트 반환 (지연 지원)
+    /// </summary>
+    public void Release(GameObject go, float delay = 0f)
+    {
+        if (go == null) return;
+        StartCoroutine(ReleaseRoutine(go, delay));
+    }
+
+    private IEnumerator ReleaseRoutine(GameObject go, float delay)
+    {
+        if (delay > 0f) yield return new WaitForSeconds(delay);
+        if (go == null) yield break;
+        var member = go.GetComponent<PoolMember>();
+        if (member == null)
+        {
+            Destroy(go);
+            yield break;
+        }
+        go.SetActive(false);
+        if (!pool.TryGetValue(member.key, out Stack<GameObject> stack))
+        {
+            stack = new Stack<GameObject>();
+            pool[member.key] = stack;
+        }
+        stack.Push(go);
+    }
+}

--- a/Assets/Scripts/Weapons/ElectricSphere.cs
+++ b/Assets/Scripts/Weapons/ElectricSphere.cs
@@ -1,0 +1,83 @@
+using UnityEngine;
+
+/// <summary>
+/// 느리게 이동하며 주변에 전기 피해를 주는 구체
+/// </summary>
+public class ElectricSphere : WeaponBase
+{
+    [Header("Electric Sphere Settings")]
+    [SerializeField] private GameObject corePrefab;
+    [SerializeField] private float coreSpeed = 2f;
+    [SerializeField] private float coreRadius = 1f;
+    [SerializeField] private float tickPerSec = 2f;
+    [SerializeField] private float fieldLinkRadius = 3f;
+    [SerializeField] private float coreLifetime = 5f;
+    [Header("Status Effect")]
+    [SerializeField] private float statusMagnitude = 0f;
+    [SerializeField] private float statusDuration = 1f;
+    [SerializeField] private float statusTickInterval = 0f;
+    [SerializeField] private int statusStacks = 1;
+
+    protected override void InitializeWeapon()
+    {
+        base.InitializeWeapon();
+        damage = 5f;
+        if (corePrefab == null)
+        {
+            corePrefab = new GameObject("ElectricSphereCore");
+            corePrefab.AddComponent<ElectricSphereCore>();
+            var sr = corePrefab.AddComponent<SpriteRenderer>();
+            sr.sprite = Resources.GetBuiltinResource<Sprite>("UI/Skin/Background.psd");
+            corePrefab.SetActive(false);
+        }
+    }
+
+    protected override void ExecuteAttack()
+    {
+        Transform target = FindNearestTarget();
+        if (target == null)
+        {
+            OnAttackComplete();
+            return;
+        }
+
+        Vector2 dir = ((Vector2)(target.position - transform.position)).normalized;
+        GameObject coreObj = SimpleObjectPool.Instance != null ?
+            SimpleObjectPool.Instance.Get(corePrefab, transform.position, Quaternion.identity) :
+            Instantiate(corePrefab, transform.position, Quaternion.identity);
+        var core = coreObj.GetComponent<ElectricSphereCore>();
+        if (core == null) core = coreObj.AddComponent<ElectricSphereCore>();
+        var effect = new StatusEffect
+        {
+            type = StatusType.Lightning,
+            magnitude = statusMagnitude,
+            duration = statusDuration,
+            tickInterval = statusTickInterval,
+            stacks = statusStacks
+        };
+        core.Initialize(dir, damage, 1f / tickPerSec, coreRadius, coreSpeed, coreLifetime, fieldLinkRadius, effect);
+
+        OnAttackComplete();
+    }
+
+    public override string GetWeaponInfo()
+    {
+        return base.GetWeaponInfo() +
+               $"\nRadius: {coreRadius:F1}" +
+               $"\nTick/s: {tickPerSec:F1}";
+    }
+
+    public void DebugFire() => TryAttack();
+
+    protected override float GetAttackRange()
+    {
+        return 10f;
+    }
+
+    protected override void OnDrawGizmosSelected()
+    {
+        base.OnDrawGizmosSelected();
+        Gizmos.color = Color.yellow;
+        Gizmos.DrawWireSphere(transform.position, coreRadius);
+    }
+}

--- a/Assets/Scripts/Weapons/ElectricSphereCore.cs
+++ b/Assets/Scripts/Weapons/ElectricSphereCore.cs
@@ -1,0 +1,152 @@
+using System.Collections.Generic;
+using UnityEngine;
+
+/// <summary>
+/// 전기 구체의 코어 처리
+/// </summary>
+[RequireComponent(typeof(Rigidbody2D), typeof(CircleCollider2D))]
+public class ElectricSphereCore : MonoBehaviour
+{
+    private float damage;
+    private float tickInterval;
+    private float radius;
+    private float speed;
+    private float lifetime;
+    private float linkRadius;
+    private DamageTag damageTag = DamageTag.Lightning;
+    private StatusEffect statusEffect;
+
+    private float lifeTimer;
+    private float tickTimer;
+
+    private Rigidbody2D rb;
+    private CircleCollider2D col;
+    private readonly HashSet<EnemyBase> enemies = new HashSet<EnemyBase>();
+
+    private void Awake()
+    {
+        rb = GetComponent<Rigidbody2D>();
+        if (rb == null) rb = gameObject.AddComponent<Rigidbody2D>();
+        rb.gravityScale = 0f;
+
+        col = GetComponent<CircleCollider2D>();
+        if (col == null) col = gameObject.AddComponent<CircleCollider2D>();
+        col.isTrigger = true;
+    }
+
+    public void Initialize(Vector2 dir, float damage, float tickInterval, float radius, float speed, float lifetime, float linkRadius, StatusEffect effect)
+    {
+        this.damage = damage;
+        this.tickInterval = tickInterval;
+        this.radius = radius;
+        this.speed = speed;
+        this.lifetime = lifetime;
+        this.linkRadius = linkRadius;
+        statusEffect = effect;
+
+        lifeTimer = 0f;
+        tickTimer = 0f;
+        enemies.Clear();
+
+        col.radius = radius;
+        rb.linearVelocity = dir.normalized * speed;
+    }
+
+    private void Update()
+    {
+        lifeTimer += Time.deltaTime;
+        tickTimer += Time.deltaTime;
+        if (lifeTimer >= lifetime)
+        {
+            Release();
+            return;
+        }
+        if (tickTimer >= tickInterval)
+        {
+            tickTimer = 0f;
+            foreach (var e in enemies)
+            {
+                if (e != null)
+                    ApplyDamage(e, damage);
+            }
+        }
+    }
+
+    private void OnTriggerEnter2D(Collider2D other)
+    {
+        if (other.CompareTag("Enemy"))
+        {
+            var enemy = other.GetComponent<EnemyBase>();
+            if (enemy != null)
+            {
+                ApplyDamage(enemy, damage);
+                enemies.Add(enemy);
+            }
+        }
+        else
+        {
+            var field = other.GetComponent<ElectricField>();
+            if (field != null)
+            {
+                SpreadPulse(field);
+            }
+        }
+    }
+
+    private void OnTriggerExit2D(Collider2D other)
+    {
+        if (other.CompareTag("Enemy"))
+        {
+            var enemy = other.GetComponent<EnemyBase>();
+            if (enemy != null)
+                enemies.Remove(enemy);
+        }
+    }
+
+    private void SpreadPulse(ElectricField start)
+    {
+        var visited = new HashSet<ElectricField>();
+        var queue = new Queue<ElectricField>();
+        queue.Enqueue(start);
+        visited.Add(start);
+
+        while (queue.Count > 0)
+        {
+            var f = queue.Dequeue();
+            f.ConfigureEffect(DamageTag.Lightning, statusEffect);
+            f.Pulse(damage, tickInterval);
+            Collider2D[] cols = Physics2D.OverlapCircleAll(f.transform.position, linkRadius);
+            foreach (var c in cols)
+            {
+                var nf = c.GetComponent<ElectricField>();
+                if (nf != null && !visited.Contains(nf))
+                {
+                    visited.Add(nf);
+                    queue.Enqueue(nf);
+                }
+            }
+        }
+    }
+
+    private void Release()
+    {
+        enemies.Clear();
+        rb.linearVelocity = Vector2.zero;
+        if (SimpleObjectPool.Instance != null)
+            SimpleObjectPool.Instance.Release(gameObject);
+        else
+            Destroy(gameObject);
+    }
+
+    private void ApplyDamage(EnemyBase enemy, float baseDamage)
+    {
+        var sc = enemy.GetComponent<StatusController>();
+        float finalDamage = baseDamage;
+        if (sc != null)
+        {
+            finalDamage *= sc.GetDamageTakenMultiplier(damageTag);
+            sc.ApplyStatus(statusEffect);
+        }
+        enemy.TakeDamage(finalDamage);
+    }
+}

--- a/Assets/Scripts/Weapons/Fields/ElectricField.cs
+++ b/Assets/Scripts/Weapons/Fields/ElectricField.cs
@@ -1,0 +1,26 @@
+using UnityEngine;
+
+/// <summary>
+/// 전기 속성 필드
+/// </summary>
+public class ElectricField : FieldBase
+{
+    [SerializeField] private float vulnerabilityMultiplier = 1f;
+
+    public void SetVulnerability(float m)
+    {
+        vulnerabilityMultiplier = m;
+    }
+
+    public void Pulse(float damage, float tickInterval)
+    {
+        this.damage = damage;
+        this.tickInterval = tickInterval;
+        Tick();
+    }
+
+    protected override void ApplyTick(EnemyBase enemy)
+    {
+        ApplyDamage(enemy, damage * vulnerabilityMultiplier);
+    }
+}

--- a/Assets/Scripts/Weapons/Fields/FieldBase.cs
+++ b/Assets/Scripts/Weapons/Fields/FieldBase.cs
@@ -1,0 +1,151 @@
+using System.Collections.Generic;
+using UnityEngine;
+
+/// <summary>
+/// 범위형 필드 기본 클래스
+/// </summary>
+[RequireComponent(typeof(CircleCollider2D))]
+public class FieldBase : MonoBehaviour
+{
+    [SerializeField] protected float radius = 1f;
+    [SerializeField] protected float duration = 3f;
+    [SerializeField] protected float tickInterval = 1f;
+    [SerializeField] protected float damage = 1f;
+    [SerializeField] protected float slowMultiplier = 1f;
+    [SerializeField] protected LayerMask targetLayer = 0;
+    [SerializeField] protected DamageTag damageTag = DamageTag.Physical;
+    [SerializeField] protected StatusEffect statusEffect;
+
+    protected readonly HashSet<EnemyBase> targets = new HashSet<EnemyBase>();
+    private float lifeTimer;
+    private float tickTimer;
+    private CircleCollider2D circle;
+
+    protected virtual void Awake()
+    {
+        circle = GetComponent<CircleCollider2D>();
+        circle.isTrigger = true;
+        circle.radius = radius;
+    }
+
+    public virtual void Setup(float radius, float duration, float tickInterval, float damage, float slowMultiplier = 1f)
+    {
+        this.radius = radius;
+        this.duration = duration;
+        this.tickInterval = tickInterval;
+        this.damage = damage;
+        this.slowMultiplier = slowMultiplier;
+        if (circle != null) circle.radius = radius;
+    }
+
+    public void ConfigureEffect(DamageTag tag, StatusEffect effect)
+    {
+        damageTag = tag;
+        statusEffect = effect;
+    }
+
+    protected virtual void OnEnable()
+    {
+        lifeTimer = 0f;
+        tickTimer = 0f;
+        targets.Clear();
+    }
+
+    protected virtual void Update()
+    {
+        lifeTimer += Time.deltaTime;
+        tickTimer += Time.deltaTime;
+        if (lifeTimer >= duration)
+        {
+            DestroyField();
+            return;
+        }
+
+        if (tickInterval > 0f && tickTimer >= tickInterval)
+        {
+            tickTimer = 0f;
+            Tick();
+        }
+    }
+
+    protected virtual void Tick()
+    {
+        foreach (var enemy in targets)
+        {
+            if (enemy != null)
+            {
+                ApplyTick(enemy);
+            }
+        }
+    }
+
+    protected virtual void ApplyTick(EnemyBase enemy)
+    {
+        ApplyDamage(enemy, damage);
+    }
+
+    protected virtual void OnTriggerEnter2D(Collider2D other)
+    {
+        if (other.CompareTag("Enemy"))
+        {
+            var enemy = other.GetComponent<EnemyBase>();
+            if (enemy != null)
+            {
+                ApplyDamage(enemy, damage);
+                if (slowMultiplier != 1f)
+                    enemy.ApplySlow(slowMultiplier);
+                targets.Add(enemy);
+            }
+        }
+    }
+
+    protected virtual void OnTriggerExit2D(Collider2D other)
+    {
+        if (other.CompareTag("Enemy"))
+        {
+            var enemy = other.GetComponent<EnemyBase>();
+            if (enemy != null)
+            {
+                if (slowMultiplier != 1f)
+                    enemy.ApplySlow(1f);
+                targets.Remove(enemy);
+            }
+        }
+    }
+
+    protected virtual void OnDestroy()
+    {
+        foreach (var enemy in targets)
+        {
+            if (enemy != null && slowMultiplier != 1f)
+                enemy.ApplySlow(1f);
+        }
+        targets.Clear();
+    }
+
+    protected virtual void DestroyField()
+    {
+        if (SimpleObjectPool.Instance != null)
+            SimpleObjectPool.Instance.Release(gameObject);
+        else
+            Destroy(gameObject);
+    }
+
+    protected virtual void OnDrawGizmosSelected()
+    {
+        Gizmos.color = Color.cyan;
+        Gizmos.DrawWireSphere(transform.position, radius);
+    }
+
+    protected void ApplyDamage(EnemyBase enemy, float baseDamage)
+    {
+        var sc = enemy.GetComponent<StatusController>();
+        float finalDamage = baseDamage;
+        if (sc != null)
+        {
+            finalDamage *= sc.GetDamageTakenMultiplier(damageTag);
+            sc.ApplyStatus(statusEffect);
+        }
+        enemy.TakeDamage(finalDamage);
+    }
+}

--- a/Assets/Scripts/Weapons/Fireball.cs
+++ b/Assets/Scripts/Weapons/Fireball.cs
@@ -1,0 +1,95 @@
+using UnityEngine;
+
+/// <summary>
+/// 적중 시 분열하는 파이어볼
+/// </summary>
+public class Fireball : WeaponBase
+{
+    [Header("Fireball Settings")]
+    [SerializeField] private GameObject projectilePrefab;
+    [SerializeField] private float projectileSpeed = 10f;
+    [SerializeField] private float projectileLifetime = 3f;
+    [SerializeField] private int splitCount = 3;
+    [Header("Status Effect")]
+    [SerializeField] private float statusMagnitude = 0f;
+    [SerializeField] private float statusDuration = 1f;
+    [SerializeField] private float statusTickInterval = 1f;
+    [SerializeField] private int statusStacks = 1;
+
+    protected override void InitializeWeapon()
+    {
+        base.InitializeWeapon();
+        damage = 5f;
+        cooldown = 1f;
+        if (projectilePrefab == null)
+        {
+            projectilePrefab = new GameObject("FireballProjectile");
+            projectilePrefab.AddComponent<PooledProjectile>();
+            var sr = projectilePrefab.AddComponent<SpriteRenderer>();
+            sr.sprite = Resources.GetBuiltinResource<Sprite>("UI/Skin/UISprite.psd");
+            projectilePrefab.SetActive(false);
+        }
+    }
+
+    protected override void ExecuteAttack()
+    {
+        Transform target = FindNearestTarget();
+        if (target == null)
+        {
+            OnAttackComplete();
+            return;
+        }
+
+        Vector2 dir = (target.position - transform.position).normalized;
+        GameObject proj = SimpleObjectPool.Instance != null ?
+            SimpleObjectPool.Instance.Get(projectilePrefab, transform.position, Quaternion.identity) :
+            Instantiate(projectilePrefab, transform.position, Quaternion.identity);
+        var p = proj.GetComponent<PooledProjectile>();
+        if (p == null) p = proj.AddComponent<PooledProjectile>();
+        var effect = new StatusEffect
+        {
+            type = StatusType.Fire,
+            magnitude = statusMagnitude,
+            duration = statusDuration,
+            tickInterval = statusTickInterval,
+            stacks = statusStacks
+        };
+        p.Initialize(damage, projectileSpeed, projectileLifetime, dir, DamageTag.Fire, effect, 1, (enemy) =>
+        {
+            if (enemy != null)
+                SpawnSplit(proj.transform.position, effect);
+        });
+
+        OnAttackComplete();
+    }
+
+    private void SpawnSplit(Vector3 pos, StatusEffect effect)
+    {
+        float angleStep = 360f / splitCount;
+        for (int i = 0; i < splitCount; i++)
+        {
+            float angle = angleStep * i;
+            Vector2 dir = Quaternion.Euler(0, 0, angle) * Vector2.right;
+            GameObject proj = SimpleObjectPool.Instance != null ?
+                SimpleObjectPool.Instance.Get(projectilePrefab, pos, Quaternion.identity) :
+                Instantiate(projectilePrefab, pos, Quaternion.identity);
+            var p = proj.GetComponent<PooledProjectile>();
+            if (p == null) p = proj.AddComponent<PooledProjectile>();
+            p.Initialize(damage, projectileSpeed, projectileLifetime, dir, DamageTag.Fire, effect, 1, null);
+        }
+    }
+
+    public override string GetWeaponInfo()
+    {
+        return base.GetWeaponInfo() + $"\nSplit: {splitCount}";
+    }
+
+    public void DebugFire() => TryAttack();
+
+    protected override float GetAttackRange() => 12f;
+
+    protected override void OnDrawGizmosSelected()
+    {
+        base.OnDrawGizmosSelected();
+    }
+}

--- a/Assets/Scripts/Weapons/FrostNova.cs
+++ b/Assets/Scripts/Weapons/FrostNova.cs
@@ -1,0 +1,89 @@
+using UnityEngine;
+
+/// <summary>
+/// 플레이어 중심으로 얼음 폭발을 일으켜 적을 느리게 함
+/// </summary>
+public class FrostNova : WeaponBase
+{
+    [Header("Frost Nova Settings")]
+    [SerializeField] private float radius = 5f;
+    [SerializeField] private bool useMultiplier = true;
+    [SerializeField] private float slowMultiplier = 0.7f;
+    [SerializeField] private float slowFlat = 0.3f;
+    [SerializeField] private float ticksPerSec = 0f;
+    [SerializeField] private float fieldDuration = 2f;
+    [SerializeField] private GameObject fieldPrefab;
+    [Header("Status Effect")]
+    [SerializeField] private float statusDuration = 2f;
+    [SerializeField] private float statusTickInterval = 1f;
+    [SerializeField] private int statusStacks = 1;
+
+    protected override void InitializeWeapon()
+    {
+        base.InitializeWeapon();
+        damage = 5f;
+        if (fieldPrefab == null)
+        {
+            fieldPrefab = new GameObject("FrostNovaField");
+            fieldPrefab.AddComponent<FieldBase>();
+            fieldPrefab.SetActive(false);
+        }
+    }
+
+    protected override void ExecuteAttack()
+    {
+        Collider2D[] hits = Physics2D.OverlapCircleAll(transform.position, radius, LayerMask.GetMask("Enemy"));
+        var effect = new StatusEffect
+        {
+            type = StatusType.Ice,
+            magnitude = useMultiplier ? slowMultiplier : slowFlat,
+            duration = statusDuration,
+            tickInterval = statusTickInterval,
+            stacks = statusStacks
+        };
+        foreach (var h in hits)
+        {
+            var enemy = h.GetComponent<EnemyBase>();
+            if (enemy != null)
+            {
+                var sc = enemy.GetComponent<StatusController>();
+                float finalDamage = damage;
+                if (sc != null)
+                {
+                    finalDamage *= sc.GetDamageTakenMultiplier(DamageTag.Ice);
+                    sc.ApplyStatus(effect);
+                }
+                enemy.TakeDamage(finalDamage);
+            }
+        }
+
+        if (ticksPerSec > 0f)
+        {
+            GameObject fieldObj = SimpleObjectPool.Instance != null ?
+                SimpleObjectPool.Instance.Get(fieldPrefab, transform.position, Quaternion.identity) :
+                Instantiate(fieldPrefab, transform.position, Quaternion.identity);
+            var field = fieldObj.GetComponent<FieldBase>();
+            if (field == null) field = fieldObj.AddComponent<FieldBase>();
+            field.Setup(radius, fieldDuration, 1f / ticksPerSec, damage);
+            field.ConfigureEffect(DamageTag.Ice, effect);
+        }
+
+        OnAttackComplete();
+    }
+
+    public override string GetWeaponInfo()
+    {
+        return $"{weaponName} Lv.{level}\nDamage: {damage:F1}\nRadius: {radius:F1}\nSlow: {(useMultiplier ? slowMultiplier : slowFlat)}";
+    }
+
+    public void DebugFire() => TryAttack();
+
+    protected override float GetAttackRange() => radius;
+
+    protected override void OnDrawGizmosSelected()
+    {
+        base.OnDrawGizmosSelected();
+        Gizmos.color = Color.cyan;
+        Gizmos.DrawWireSphere(transform.position, radius);
+    }
+}

--- a/Assets/Scripts/Weapons/PooledProjectile.cs
+++ b/Assets/Scripts/Weapons/PooledProjectile.cs
@@ -1,0 +1,101 @@
+using System;
+using UnityEngine;
+
+/// <summary>
+/// 풀에서 사용하는 기본 투사체
+/// </summary>
+[RequireComponent(typeof(Rigidbody2D), typeof(Collider2D))]
+public class PooledProjectile : MonoBehaviour
+{
+    private Rigidbody2D rb;
+    private Collider2D col;
+    private TrailRenderer trail;
+
+    private float damage;
+    private float speed;
+    private float lifetime;
+    private Vector2 direction;
+    private int pierce;
+    private Action<EnemyBase> onHit;
+    private DamageTag damageTag = DamageTag.Physical;
+    private StatusEffect statusEffect;
+
+    private float spawnTime;
+
+    private void Awake()
+    {
+        rb = GetComponent<Rigidbody2D>();
+        if (rb == null) rb = gameObject.AddComponent<Rigidbody2D>();
+        rb.gravityScale = 0f;
+
+        col = GetComponent<Collider2D>();
+        if (col == null) col = gameObject.AddComponent<CircleCollider2D>();
+        col.isTrigger = true;
+
+        trail = GetComponent<TrailRenderer>();
+    }
+
+    /// <summary>
+    /// 초기화
+    /// </summary>
+    public void Initialize(float dmg, float spd, float life, Vector2 dir, DamageTag tag, StatusEffect effect, int pierceCount = 1, Action<EnemyBase> onHit = null)
+    {
+        damage = dmg;
+        speed = spd;
+        lifetime = life;
+        direction = dir.normalized;
+        pierce = pierceCount;
+        this.onHit = onHit;
+        damageTag = tag;
+        statusEffect = effect;
+        spawnTime = Time.time;
+
+        rb.linearVelocity = direction * speed;
+
+        if (trail != null) trail.Clear();
+    }
+
+    private void Update()
+    {
+        if (Time.time >= spawnTime + lifetime)
+        {
+            onHit?.Invoke(null);
+            Release();
+        }
+    }
+
+    private void OnTriggerEnter2D(Collider2D other)
+    {
+        if (other.CompareTag("Enemy"))
+        {
+            var enemy = other.GetComponent<EnemyBase>();
+            if (enemy != null)
+            {
+                var sc = enemy.GetComponent<StatusController>();
+                float finalDamage = damage;
+                if (sc != null)
+                {
+                    finalDamage *= sc.GetDamageTakenMultiplier(damageTag);
+                    sc.ApplyStatus(statusEffect);
+                }
+                enemy.TakeDamage(finalDamage);
+                onHit?.Invoke(enemy);
+            }
+
+            pierce--;
+            if (pierce <= 0)
+            {
+                Release();
+            }
+        }
+    }
+
+    private void Release()
+    {
+        rb.linearVelocity = Vector2.zero;
+        if (SimpleObjectPool.Instance != null)
+            SimpleObjectPool.Instance.Release(gameObject);
+        else
+            Destroy(gameObject);
+    }
+}

--- a/Assets/Scripts/Weapons/RainingFire.cs
+++ b/Assets/Scripts/Weapons/RainingFire.cs
@@ -1,0 +1,114 @@
+using UnityEngine;
+
+/// <summary>
+/// 랜덤 위치에 화염구를 떨어뜨려 화염 지대를 생성
+/// </summary>
+public class RainingFire : WeaponBase
+{
+    [Header("Raining Fire Settings")]
+    [SerializeField] private GameObject fireballPrefab;
+    [SerializeField] private GameObject fieldPrefab;
+    [SerializeField] private float fallRate = 1f;
+    [SerializeField] private float impactDamage = 10f;
+    [SerializeField] private float fieldRadius = 2f;
+    [SerializeField] private float fieldDamage = 3f;
+    [SerializeField] private float fieldDuration = 3f;
+    [SerializeField] private float fieldTickPerSec = 1f;
+    [SerializeField] private float spawnRange = 6f;
+    [Header("Status Effect")]
+    [SerializeField] private float statusMagnitude = 0f;
+    [SerializeField] private float statusDuration = 1f;
+    [SerializeField] private float statusTickInterval = 1f;
+    [SerializeField] private int statusStacks = 1;
+
+    protected override void InitializeWeapon()
+    {
+        base.InitializeWeapon();
+        cooldown = 1f / fallRate;
+        damage = impactDamage;
+        if (fireballPrefab == null)
+        {
+            fireballPrefab = new GameObject("Fireball");
+            fireballPrefab.AddComponent<PooledProjectile>();
+            var sr = fireballPrefab.AddComponent<SpriteRenderer>();
+            sr.sprite = Resources.GetBuiltinResource<Sprite>("UI/Skin/UISprite.psd");
+            fireballPrefab.SetActive(false);
+        }
+        if (fieldPrefab == null)
+        {
+            fieldPrefab = new GameObject("FireField");
+            fieldPrefab.AddComponent<FieldBase>();
+            fieldPrefab.SetActive(false);
+        }
+    }
+
+    protected override void ExecuteAttack()
+    {
+        Vector2 spawnPos = (Vector2)transform.position + Random.insideUnitCircle * spawnRange;
+        Vector2 startPos = spawnPos + Vector2.up * 5f;
+        float speed = 10f;
+        float lifetime = 5f / speed; // 높이 5 기준
+
+        GameObject proj = SimpleObjectPool.Instance != null ?
+            SimpleObjectPool.Instance.Get(fireballPrefab, startPos, Quaternion.identity) :
+            Instantiate(fireballPrefab, startPos, Quaternion.identity);
+
+        var pooled = proj.GetComponent<PooledProjectile>();
+        if (pooled == null) pooled = proj.AddComponent<PooledProjectile>();
+
+        var effect = new StatusEffect
+        {
+            type = StatusType.Fire,
+            magnitude = statusMagnitude,
+            duration = statusDuration,
+            tickInterval = statusTickInterval,
+            stacks = statusStacks
+        };
+        pooled.Initialize(impactDamage, speed, lifetime, Vector2.down, DamageTag.Fire, effect, 1, (enemy) =>
+        {
+            SpawnField(proj.transform.position, effect);
+        });
+
+        OnAttackComplete();
+    }
+
+    private void SpawnField(Vector3 pos, StatusEffect effect)
+    {
+        GameObject fieldObj = SimpleObjectPool.Instance != null ?
+            SimpleObjectPool.Instance.Get(fieldPrefab, pos, Quaternion.identity) :
+            Instantiate(fieldPrefab, pos, Quaternion.identity);
+        var field = fieldObj.GetComponent<FieldBase>();
+        if (field == null) field = fieldObj.AddComponent<FieldBase>();
+        field.Setup(fieldRadius, fieldDuration, 1f / fieldTickPerSec, fieldDamage);
+        field.ConfigureEffect(DamageTag.Fire, effect);
+    }
+
+    public override void ApplyDamageMultiplier(float m)
+    {
+        base.ApplyDamageMultiplier(m);
+        impactDamage *= m;
+        fieldDamage *= m;
+    }
+
+    public override void ApplyCooldownMultiplier(float m)
+    {
+        base.ApplyCooldownMultiplier(m);
+        fallRate = 1f / cooldown;
+    }
+
+    public override string GetWeaponInfo()
+    {
+        return $"{weaponName} Lv.{level}\nImpact: {impactDamage:F1}\nField DPS: {fieldDamage * fieldTickPerSec:F1}\nCooldown: {cooldown:F2}s";
+    }
+
+    public void DebugFire() => TryAttack();
+
+    protected override float GetAttackRange() => spawnRange;
+
+    protected override void OnDrawGizmosSelected()
+    {
+        base.OnDrawGizmosSelected();
+        Gizmos.color = Color.red;
+        Gizmos.DrawWireSphere(transform.position, spawnRange);
+    }
+}

--- a/Assets/Scripts/Weapons/Thunder.cs
+++ b/Assets/Scripts/Weapons/Thunder.cs
@@ -1,0 +1,124 @@
+using UnityEngine;
+
+/// <summary>
+/// 번개 낙뢰와 전기 지대를 생성
+/// </summary>
+public class Thunder : WeaponBase
+{
+    [Header("Thunder Settings")]
+    [SerializeField] private GameObject lightningPrefab;
+    [SerializeField] private GameObject fieldPrefab;
+    [SerializeField] private float strikeDamage = 5f;
+    [SerializeField] private float fieldRadius = 3f;
+    [SerializeField] private float fieldTickPerSec = 0.5f;
+    [SerializeField] private float fieldDuration = 4f;
+    [SerializeField] private float vulnMultiplier = 1.1f;
+    [Header("Status Effect")]
+    [SerializeField] private float statusMagnitude = 0f;
+    [SerializeField] private float statusDuration = 1f;
+    [SerializeField] private float statusTickInterval = 1f;
+    [SerializeField] private int statusStacks = 1;
+
+    protected override void InitializeWeapon()
+    {
+        base.InitializeWeapon();
+        damage = strikeDamage;
+        if (fieldPrefab == null)
+        {
+            fieldPrefab = new GameObject("ThunderField");
+            fieldPrefab.AddComponent<ElectricField>();
+            fieldPrefab.SetActive(false);
+        }
+    }
+
+    protected override void ExecuteAttack()
+    {
+        Transform target = FindNearestTarget();
+        Vector3 pos = target != null ? target.position : transform.position;
+        var effect = new StatusEffect
+        {
+            type = StatusType.Lightning,
+            magnitude = statusMagnitude,
+            duration = statusDuration,
+            tickInterval = statusTickInterval,
+            stacks = statusStacks
+        };
+        if (target != null)
+        {
+            var enemy = target.GetComponent<EnemyBase>();
+            if (enemy != null)
+            {
+                var sc = enemy.GetComponent<StatusController>();
+                float finalDamage = strikeDamage;
+                if (sc != null)
+                {
+                    finalDamage *= sc.GetDamageTakenMultiplier(DamageTag.Lightning);
+                    sc.ApplyStatus(effect);
+                }
+                enemy.TakeDamage(finalDamage);
+            }
+        }
+
+        SpawnEffect(pos);
+
+        GameObject fieldObj = SimpleObjectPool.Instance != null ?
+            SimpleObjectPool.Instance.Get(fieldPrefab, pos, Quaternion.identity) :
+            Instantiate(fieldPrefab, pos, Quaternion.identity);
+        var field = fieldObj.GetComponent<ElectricField>();
+        if (field == null) field = fieldObj.AddComponent<ElectricField>();
+        field.Setup(fieldRadius, fieldDuration, 1f / fieldTickPerSec, strikeDamage);
+        field.ConfigureEffect(DamageTag.Lightning, effect);
+        field.SetVulnerability(vulnMultiplier);
+
+        OnAttackComplete();
+    }
+
+    private void SpawnEffect(Vector3 pos)
+    {
+        if (lightningPrefab != null)
+        {
+            GameObject fx = SimpleObjectPool.Instance != null ?
+                SimpleObjectPool.Instance.Get(lightningPrefab, pos, Quaternion.identity) :
+                Instantiate(lightningPrefab, pos, Quaternion.identity);
+            if (SimpleObjectPool.Instance != null)
+                SimpleObjectPool.Instance.Release(fx, 0.3f);
+            else
+                Destroy(fx, 0.3f);
+        }
+        else
+        {
+            GameObject line = new GameObject("Lightning");
+            var lr = line.AddComponent<LineRenderer>();
+            lr.positionCount = 2;
+            lr.SetPosition(0, transform.position);
+            lr.SetPosition(1, pos);
+            lr.startWidth = lr.endWidth = 0.1f;
+            if (SimpleObjectPool.Instance != null)
+                SimpleObjectPool.Instance.Release(line, 0.2f);
+            else
+                Destroy(line, 0.2f);
+        }
+    }
+
+    public override void ApplyDamageMultiplier(float m)
+    {
+        base.ApplyDamageMultiplier(m);
+        strikeDamage *= m;
+    }
+
+    public override string GetWeaponInfo()
+    {
+        return $"{weaponName} Lv.{level}\nStrike: {strikeDamage:F1}\nField DPS: {strikeDamage * fieldTickPerSec * vulnMultiplier:F1}";
+    }
+
+    public void DebugFire() => TryAttack();
+
+    protected override float GetAttackRange() => 10f;
+
+    protected override void OnDrawGizmosSelected()
+    {
+        base.OnDrawGizmosSelected();
+        Gizmos.color = Color.yellow;
+        Gizmos.DrawWireSphere(transform.position, fieldRadius);
+    }
+}

--- a/Assets/Scripts/Weapons/WeaponBase.cs
+++ b/Assets/Scripts/Weapons/WeaponBase.cs
@@ -121,6 +121,22 @@ public abstract class WeaponBase : MonoBehaviour
         // 기본적으로 데미지 10% 증가
         damage *= 1.1f;
     }
+
+    /// <summary>
+    /// 데미지 배수 적용
+    /// </summary>
+    public virtual void ApplyDamageMultiplier(float m)
+    {
+        damage *= m;
+    }
+
+    /// <summary>
+    /// 쿨다운 배수 적용
+    /// </summary>
+    public virtual void ApplyCooldownMultiplier(float m)
+    {
+        cooldown *= m;
+    }
     
     /// <summary>
     /// 공격 사운드 재생


### PR DESCRIPTION
## Summary
- add status effect framework (`StatusController`, enums, and structs)
- teach projectiles and fields to respect damage tags and apply statuses
- enable ElectricSphere, RainingFire, FrostNova, Fireball, and Thunder to inflict elemental effects with proper damage scaling

## Testing
- `dotnet build` *(fails: command not found)*
- `mcs -version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68997e3472648320ba8682075376f82d